### PR TITLE
Simplifying implementations of IPuzzleSolver

### DIFF
--- a/Source/Common/Interfaces/IPuzzleSolver.cs
+++ b/Source/Common/Interfaces/IPuzzleSolver.cs
@@ -3,17 +3,33 @@ namespace Common.Interfaces;
 public interface IPuzzleSolver
 {
     string Title { get; }
-    
-    string Part1Solution { get; set; }
 
-    string Part2Solution { get; set; }
-    
-    void SolvePuzzle(string[] input);
+    // Need not be set in implementation class
+    object? Part1Solution { get; set; }
+
+    // Need not be set in implementation class
+    object? Part2Solution { get; set; }
+
+    void SolvePuzzle(string[] input)
+    {
+        SolvePart1(input);
+        SolvePart2(input);
+    }
+
+    void SolvePart1(string[] input)
+    {
+        Part1Solution = GetPart1Solution(input);
+    }
+
+    void SolvePart2(string[] input)
+    {
+        Part2Solution = GetPart2Solution(input);
+    }
+
+    object GetPart1Solution(string[] input);
+
+    object GetPart2Solution(string[] input);
 
     // Only applicable for puzzles where part 1 and part 2 use different example input files
-    virtual bool UsePartSpecificExampleInputFiles => false;
-
-    virtual void SolvePart1(string[] input) { }
-
-    virtual void SolvePart2(string[] input) { }
+    bool UsePartSpecificExampleInputFiles => false;
 }

--- a/Source/Year2020/Day01/Solver.cs
+++ b/Source/Year2020/Day01/Solver.cs
@@ -5,23 +5,15 @@ namespace Year2020;
 public class Day01Solver : IPuzzleSolver
 {
     public string Title => "Report Repair";
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
-
-    public void SolvePuzzle(string[] input)
-    {
-        var report = input
-            .Select(int.Parse)
-            .ToArray();
-
-        Part1Solution = SolvePart1(report).ToString();
-        Part2Solution = SolvePart2(report).ToString();
-    }
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
     private const int Sum = 2020;
 
-    private static int SolvePart1(IReadOnlyList<int> report)
+    public object GetPart1Solution(string[] input)
     {
+        var report = GetReport(input);
+
         var differences = new HashSet<int>();
 
         foreach (var expense in report)
@@ -39,9 +31,11 @@ public class Day01Solver : IPuzzleSolver
         return -1;
     }
 
-    private static int SolvePart2(IReadOnlyList<int> report)
+    public object GetPart2Solution(string[] input)
     {
-        for (var i = 0; i < report.Count - 2; i++)
+        var report = GetReport(input);
+        
+        for (var i = 0; i < report.Length - 2; i++)
         {
             var expense1 = report[i];
             var missingExpenses = Sum - expense1;
@@ -58,5 +52,12 @@ public class Day01Solver : IPuzzleSolver
         }
 
         return -1;
+    }
+
+    private static int[] GetReport(IEnumerable<string> input)
+    {
+        return input
+            .Select(int.Parse)
+            .ToArray();
     }
 }

--- a/Source/Year2020/Day02/Solver.cs
+++ b/Source/Year2020/Day02/Solver.cs
@@ -5,24 +5,13 @@ namespace Year2020;
 public class Day02Solver : IPuzzleSolver
 {
     public string Title => "Password Philosophy";
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
-    public void SolvePuzzle(string[] input)
+    public object GetPart1Solution(string[] input)
     {
-        var passwordPolicies = input
-            .Select(line => line.Split(':'))
-            .Select(lineParts => new PasswordPolicy(
-                lineParts[1],
-                lineParts[0].AsPolicy()))
-            .ToList();
-
-        Part1Solution = SolvePart1(passwordPolicies).ToString();
-        Part2Solution = SolvePart2(passwordPolicies).ToString();
-    }
-
-    private static int SolvePart1(IEnumerable<PasswordPolicy> passwordPolicies)
-    {
+        var passwordPolicies = GetPasswordPolicies(input);
+        
         var validPasswords = passwordPolicies
             .Select(pp => (
                 RequiredCharacterCount: pp.Password.Count(ch => ch.Equals(pp.Policy.RequiredCharacter)),
@@ -35,40 +24,52 @@ public class Day02Solver : IPuzzleSolver
         return validPasswords;
     }
 
-    private static int SolvePart2(IEnumerable<PasswordPolicy> passwordPolicies)
+    public object GetPart2Solution(string[] input)
     {
+        var passwordPolicies = GetPasswordPolicies(input);
+        
         var validPasswords = passwordPolicies
             .Select(pp => (
                 RequiredCharIsAtFirstSpecifiedIndex:
-                    pp.Password[pp.Policy.FirstRequirement].Equals(pp.Policy.RequiredCharacter),
+                pp.Password[pp.Policy.FirstRequirement].Equals(pp.Policy.RequiredCharacter),
                 RequiredCharIsAtSecondSpecifiedIndex:
-                    pp.Password[pp.Policy.SecondRequirement].Equals(pp.Policy.RequiredCharacter)))
+                pp.Password[pp.Policy.SecondRequirement].Equals(pp.Policy.RequiredCharacter)))
             .Count(passwordProperties =>
                 passwordProperties.RequiredCharIsAtFirstSpecifiedIndex != passwordProperties.RequiredCharIsAtSecondSpecifiedIndex);
 
         return validPasswords;
     }
 
-    private record PasswordPolicy(
-        string Password,
-        Policy Policy);
-
-    public record Policy(
-        char RequiredCharacter,
-        int FirstRequirement,
-        int SecondRequirement);
+    private IEnumerable<PasswordPolicy> GetPasswordPolicies(string[] input)
+    {
+        return input
+            .Select(line => line.Split(':'))
+            .Select(lineParts => new PasswordPolicy(
+                lineParts[1],
+                lineParts[0].AsPolicy()))
+            .ToList();
+    }
 }
 
-internal static class Helpers
+internal record PasswordPolicy(
+    string Password,
+    Policy Policy);
+
+internal record Policy(
+    char RequiredCharacter,
+    int FirstRequirement,
+    int SecondRequirement);
+
+internal static class Day02Helpers
 {
-    public static Day02Solver.Policy AsPolicy(this string policyString)
+    public static Policy AsPolicy(this string policyString)
     {
         var policyAndRequiredCharacter = policyString.Split(' ');
         
         var requirements = policyAndRequiredCharacter[0].Split('-');
         var requiredCharacter = char.Parse(policyAndRequiredCharacter[1]);
 
-        return new Day02Solver.Policy(
+        return new Policy(
             requiredCharacter,
             int.Parse(requirements[0]),
             int.Parse(requirements[1]));

--- a/Source/Year2020/Day03/Solver.cs
+++ b/Source/Year2020/Day03/Solver.cs
@@ -6,25 +6,14 @@ namespace Year2020;
 public class Day03Solver : IPuzzleSolver
 {
     public string Title => "Toboggan Trajectory";
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
     private const char TreeChar = '#';
 
-    public void SolvePuzzle(string[] input)
+    public object GetPart1Solution(string[] input)
     {
-        var treeMap = input
-            .Select(line => line
-                .Select(ch => ch == TreeChar)
-                .ToList())
-            .ToList();
-        
-        Part1Solution = SolvePart1(treeMap).ToString();
-        Part2Solution = SolvePart2(treeMap).ToString();
-    }
-
-    private static int SolvePart1(IReadOnlyList<IReadOnlyList<bool>> treeMap)
-    {
+        var treeMap = GetTreeMap(input);
         var slope = new Coordinate(3, 1);
 
         var treeCount = treeMap.GetTreeCountFor(slope);
@@ -32,8 +21,10 @@ public class Day03Solver : IPuzzleSolver
         return treeCount;
     }
 
-    private static long SolvePart2(IReadOnlyList<IReadOnlyList<bool>> treeMap)
+    public object GetPart2Solution(string[] input)
     {
+        var treeMap = GetTreeMap(input);
+        
         var slopes = new Coordinate[]
         {
             new(1, 1),
@@ -48,6 +39,15 @@ public class Day03Solver : IPuzzleSolver
             (acc, slope) => acc * treeMap.GetTreeCountFor(slope));
 
         return treeCountsMultiplied;
+    }
+
+    private static IReadOnlyList<IReadOnlyList<bool>> GetTreeMap(string[] input)
+    {
+        return input
+            .Select(line => line
+                .Select(ch => ch == TreeChar)
+                .ToList())
+            .ToList();
     }
 }
 

--- a/Source/Year2020Tests/TestsBase.cs
+++ b/Source/Year2020Tests/TestsBase.cs
@@ -90,12 +90,12 @@ public abstract class TestsBase
 
     private void VerifyPart1SolutionAgainstExpectedOutput(string expected)
     {
-        Assert.AreEqual(expected, PuzzleSolver.Part1Solution, "(Part 1)");
+        Assert.AreEqual(expected, PuzzleSolver.Part1Solution?.ToString(), "(Part 1)");
     }
 
     private void VerifyPart2SolutionAgainstExpectedOutput(string expected)
     {
-        Assert.AreEqual(expected, PuzzleSolver.Part2Solution, "(Part 2)");
+        Assert.AreEqual(expected, PuzzleSolver.Part2Solution?.ToString(), "(Part 2)");
     }
 
     private string[] GetContentOf(string fileName)

--- a/Source/Year2021/Day01/Solver.cs
+++ b/Source/Year2021/Day01/Solver.cs
@@ -5,22 +5,13 @@ namespace Year2021;
 public class Day01Solver : IPuzzleSolver
 {
 	public string Title => "Sonar Sweep";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var input = rawInput
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.Select(int.Parse)
-			.ToArray();
-
-		Part1Solution = SolvePart1(input).ToString();
-		Part2Solution = SolvePart2(input).ToString();
-	}
-
-	private static int SolvePart1(IReadOnlyList<int> sonarSweepReport)
-	{
+		var sonarSweepReport = GetSonarSweepReport(input);
+		
 		var prevDepth = sonarSweepReport[0];
 		var increaseCount = 0;
 
@@ -37,8 +28,10 @@ public class Day01Solver : IPuzzleSolver
 		return increaseCount;
 	}
 
-	private static int SolvePart2(IReadOnlyList<int> sonarSweepReport)
+	public object GetPart2Solution(string[] input)
 	{
+		var sonarSweepReport = GetSonarSweepReport(input);
+		
 		var prevDepthSum = sonarSweepReport.GetDepthSumForWindowAt(0);
 		var increaseCount = 0;
 
@@ -55,6 +48,14 @@ public class Day01Solver : IPuzzleSolver
 		}
 
 		return increaseCount;
+	}
+
+	private static IReadOnlyList<int> GetSonarSweepReport(string[] input)
+	{
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.Select(int.Parse)
+			.ToArray();
 	}
 }
 

--- a/Source/Year2021/Day02/Solver.cs
+++ b/Source/Year2021/Day02/Solver.cs
@@ -5,27 +5,17 @@ namespace Year2021;
 public class Day02Solver : IPuzzleSolver
 {
 	public string Title => "Dive!";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
-
-	public void SolvePuzzle(string[] rawInput)
-	{
-		var input = rawInput
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.Select(entry => entry.Split(' '))
-			.Select(entry => (entry[0], int.Parse(entry[1])))
-			.ToList();
-
-		Part1Solution = SolvePart1(input).ToString();
-		Part2Solution = SolvePart2(input).ToString();
-	}
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
 	private const string Forward = "forward";
 	private const string Down = "down";
 	private const string Up = "up";
 
-	private static int SolvePart1(List<(string Action, int Units)> commands)
+	public object GetPart1Solution(string[] input)
 	{
+		var commands = GetCommands(input);
+		
 		var pos = 0;
 		var depth = 0;
 
@@ -38,8 +28,10 @@ public class Day02Solver : IPuzzleSolver
 		return pos * depth;
 	}
 
-	private static int SolvePart2(List<(string Action, int Units)> commands)
+	public object GetPart2Solution(string[] input)
 	{
+		var commands = GetCommands(input);
+		
 		var pos = 0;
 		var aim = 0;
 		var depth = 0;
@@ -56,6 +48,15 @@ public class Day02Solver : IPuzzleSolver
 		}
 
 		return pos * depth;
+	}
+
+	private static List<(string Action, int Units)> GetCommands(string[] input)
+	{
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.Select(entry => entry.Split(' '))
+			.Select(entry => (entry[0], int.Parse(entry[1])))
+			.ToList();
 	}
 
 	private static int GetHorizontalChange(string action, int value) => action switch

--- a/Source/Year2021/Day03/Solver.cs
+++ b/Source/Year2021/Day03/Solver.cs
@@ -1,26 +1,17 @@
-﻿using System.Globalization;
-using Common.Interfaces;
+﻿using Common.Interfaces;
 
 namespace Year2021;
 
 public class Day03Solver : IPuzzleSolver
 {
 	public string Title => "Binary Diagnostic";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var input = rawInput
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.ToArray();
-
-		Part1Solution = SolvePart1(input).ToString(CultureInfo.InvariantCulture);
-		Part2Solution = SolvePart2(input).ToString(CultureInfo.InvariantCulture);
-	}
-
-	private static decimal SolvePart1(string[] diagnosticReport)
-	{
+		var diagnosticReport = GetDiagnosticReport(input);
+		
 		var bitCount = diagnosticReport.First().Length;
 		
 		var gammaRateBinary = new List<int>();
@@ -40,14 +31,23 @@ public class Day03Solver : IPuzzleSolver
 		return powerConsumption;
 	}
 
-	private static decimal SolvePart2(string[] diagnosticReport)
+	public object GetPart2Solution(string[] input)
 	{
+		var diagnosticReport = GetDiagnosticReport(input);
+		
 		var binaryOxygenGeneratorRating = diagnosticReport.BinaryRating(OxygenCriteriaValidator);
 		var binaryCo2ScrubberRating = diagnosticReport.BinaryRating(Co2CriteriaValidator);
 
 		decimal lifeSupportRating = binaryOxygenGeneratorRating.ToDecimal() * binaryCo2ScrubberRating.ToDecimal();
 
 		return lifeSupportRating;
+	}
+
+	private string[] GetDiagnosticReport(string[] input)
+	{
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.ToArray();
 	}
 
 	private static bool OxygenCriteriaValidator(int bit, IEnumerable<int> bits) => bit == bits.MostCommonBitOr1();

--- a/Source/Year2021/Day04/Solver.cs
+++ b/Source/Year2021/Day04/Solver.cs
@@ -5,46 +5,14 @@ namespace Year2021;
 public class Day04Solver : IPuzzleSolver
 {
 	public string Title => "Giant Squid";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var drawStack = rawInput
-			.First()
-			.Split(',')
-			.Select(int.Parse)
-			.ToList();
-
-		var input = rawInput
-			.Skip(1)
-			.SkipWhile(string.IsNullOrWhiteSpace);
-
-		var boards = new List<List<int>>();
-
-		while (input.Any())
-		{
-			var board = input
-				.TakeWhile(line => !string.IsNullOrWhiteSpace(line))
-				.SelectMany(row => row
-					.Split(' ')
-					.Where(entry => !string.IsNullOrWhiteSpace(entry))
-					.Select(int.Parse))
-				.ToList();
-
-			boards.Add(board);
-
-			input = input
-				.SkipWhile(line => !string.IsNullOrWhiteSpace(line))
-				.SkipWhile(string.IsNullOrWhiteSpace);
-		}
-
-		Part1Solution = SolvePart1(boards, drawStack).ToString();
-		Part2Solution = SolvePart2(boards, drawStack).ToString();
-	}
-
-	private static int SolvePart1(List<List<int>> boards, List<int> drawStack)
-	{
+		var drawStack = GetDrawStack(input);
+		var boards = GetBoards(input);
+		
 		var playingBoards = boards
 			.Select(board => board
 				.Select(entry => (int?)entry)
@@ -63,8 +31,11 @@ public class Day04Solver : IPuzzleSolver
 		return finalScore ?? -1;
 	}
 
-	private static int SolvePart2(List<List<int>> boards, List<int> drawStack)
+	public object GetPart2Solution(string[] input)
 	{
+		var drawStack = GetDrawStack(input);
+		var boards = GetBoards(input);
+		
 		var remainingBoards = boards
 			.Select(board => board
 				.Select(entry => (int?)entry)
@@ -94,6 +65,45 @@ public class Day04Solver : IPuzzleSolver
 		}
 
 		return -1;
+	}
+
+	private static List<int> GetDrawStack(string[] input)
+	{
+		return input
+			.First()
+			.Split(',')
+			.Select(int.Parse)
+			.ToList();
+	}
+
+	private static List<List<int>> GetBoards(string[] input)
+	{
+		var boardInput = input
+			.Skip(1)
+			.SkipWhile(string.IsNullOrWhiteSpace)
+			.ToList();
+
+		var boards = new List<List<int>>();
+
+		while (boardInput.Any())
+		{
+			var board = boardInput
+				.TakeWhile(line => !string.IsNullOrWhiteSpace(line))
+				.SelectMany(row => row
+					.Split(' ')
+					.Where(entry => !string.IsNullOrWhiteSpace(entry))
+					.Select(int.Parse))
+				.ToList();
+
+			boards.Add(board);
+
+			boardInput = boardInput
+				.SkipWhile(line => !string.IsNullOrWhiteSpace(line))
+				.SkipWhile(string.IsNullOrWhiteSpace)
+				.ToList();
+		}
+
+		return boards;
 	}
 }
 

--- a/Source/Year2021/Day05/Solver.cs
+++ b/Source/Year2021/Day05/Solver.cs
@@ -5,41 +5,53 @@ namespace Year2021;
 public class Day05Solver : IPuzzleSolver
 {
 	public string Title => "Hydrothermal Venture";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var input = rawInput
+		var segments = GetSegments(input);
+		var maxRowIndex = GetMaxRowIndex(segments);
+		var maxColIndex = GetMaxColIndex(segments);
+		
+		return Solve(segments, maxRowIndex, maxColIndex);
+	}
+
+	public object GetPart2Solution(string[] input)
+	{
+		var segments = GetSegments(input);
+		var maxRowIndex = GetMaxRowIndex(segments);
+		var maxColIndex = GetMaxColIndex(segments);
+		
+		return Solve(segments, maxRowIndex, maxColIndex, true);
+	}
+
+	private static List<Segment> GetSegments(string[] input)
+	{
+		return input
 			.Where(line => !string.IsNullOrEmpty(line))
 			.Select(line => line.Split(' '))
-			.Select(coordinate => new Segment(coordinate[0], coordinate[2]));
+			.Select(coordinate => new Segment(coordinate[0], coordinate[2]))
+			.ToList();
+	}
 
-		var xMax = input
+	private static int GetMaxRowIndex(IEnumerable<Segment> segments)
+	{
+		return segments
 			.Select(segment => Math.Max(segment.X1, segment.X2))
 			.Distinct()
 			.Max();
+	}
 
-		var yMax = input
+	private static int GetMaxColIndex(IEnumerable<Segment> segments)
+	{
+		return segments
 			.Select(segment => Math.Max(segment.Y1, segment.Y2))
 			.Distinct()
 			.Max();
-
-		Part1Solution = SolvePart1(input, xMax, yMax).ToString();
-		Part2Solution = SolvePart2(input, xMax, yMax).ToString();
 	}
 
-	private static int SolvePart1(IEnumerable<Segment> linesOfVents, int maxRowIndex, int maxColIndex)
-	{
-		return Solve(linesOfVents, maxRowIndex, maxColIndex);
-	}
-
-	private static int SolvePart2(IEnumerable<Segment> linesOfVents, int maxRowIndex, int maxColIndex)
-	{
-		return Solve(linesOfVents, maxRowIndex, maxColIndex, true);
-	}
-
-	private static int Solve(IEnumerable<Segment> linesOfVents, int maxRowIndex, int maxColIndex, bool includeDiagonalLines = false)
+	private static int Solve(IReadOnlyList<Segment> linesOfVents, int maxRowIndex, int maxColIndex, bool includeDiagonalLines = false)
 	{
 		var overlapMap = new int[maxRowIndex + 1, maxColIndex + 1];
 
@@ -70,7 +82,7 @@ public class Day05Solver : IPuzzleSolver
 	}
 }
 
-static class Day05Helpers
+internal static class Day05Helpers
 {
 	public static IEnumerable<HorizontalSegment> HorizontalSegments(this IEnumerable<Segment> segments)
 	{
@@ -162,7 +174,7 @@ static class Day05Helpers
 	}
 }
 
-public class HorizontalSegment
+internal class HorizontalSegment
 {
 	public HorizontalSegment(int x1, int x2, int y) 
 	{
@@ -176,7 +188,7 @@ public class HorizontalSegment
 	public int Y { get; }
 }
 
-public class VerticalSegment
+internal class VerticalSegment
 {
 	public VerticalSegment(int x, int y1, int y2)
 	{
@@ -190,7 +202,7 @@ public class VerticalSegment
 	public int Y2 { get; }
 }
 
-public class DiagonalSegment
+internal class DiagonalSegment
 {
 	public DiagonalSegment(int xStart, int yStart, int length, bool isPointingUpwards)
 	{
@@ -206,7 +218,7 @@ public class DiagonalSegment
 	public bool IsPointingUpwards { get; }
 }
 
-public class Segment
+internal class Segment
 {
 	public Segment(string startPoint, string endPoint)
 	{

--- a/Source/Year2021/Day06/Solver.cs
+++ b/Source/Year2021/Day06/Solver.cs
@@ -1,29 +1,17 @@
-﻿using System.Globalization;
-using Common.Interfaces;
+﻿using Common.Interfaces;
 
 namespace Year2021;
 
 public class Day06Solver : IPuzzleSolver
 {
 	public string Title => "Lanternfish";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var input = rawInput
-			.Single(entry => !string.IsNullOrWhiteSpace(entry))
-			.Split(',')
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.Select(int.Parse)
-			.ToArray();
-
-		Part1Solution = SolvePart1(input).ToString();
-		Part2Solution = SolvePart2(input).ToString(CultureInfo.InvariantCulture);
-	}
-
-	private static int SolvePart1(IEnumerable<int> timerValues)
-	{
+		var timerValues = GetTimerValues(input);
+		
 		var shoal = timerValues.ToList();
 
 		foreach (var _ in Enumerable.Range(0, 80))
@@ -34,8 +22,10 @@ public class Day06Solver : IPuzzleSolver
 		return shoal.Count;
 	}
 
-	private static decimal SolvePart2(IEnumerable<int> timerValues)
+	public object GetPart2Solution(string[] input)
 	{
+		var timerValues = GetTimerValues(input);
+		
 		var fishCountPerTimerValue =
 			Enumerable.Repeat((decimal)0, Day06Helpers.TimerValueForSpawn + 1).ToList();
 
@@ -51,9 +41,19 @@ public class Day06Solver : IPuzzleSolver
 
 		return fishCountPerTimerValue.Sum();
 	}
+
+	private IEnumerable<int> GetTimerValues(string[] input)
+	{
+		return input
+			.Single(entry => !string.IsNullOrWhiteSpace(entry))
+			.Split(',')
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.Select(int.Parse)
+			.ToArray();
+	}
 }
 
-public static class Day06Helpers
+internal static class Day06Helpers
 {
 	public const int TimerValueForSpawn = 8;
 	private const int TimerValuePreSpawning = 0;

--- a/Source/Year2021/Day07/Solver.cs
+++ b/Source/Year2021/Day07/Solver.cs
@@ -1,28 +1,17 @@
-﻿using System.Globalization;
-using Common.Interfaces;
+﻿using Common.Interfaces;
 
 namespace Year2021;
 
 public class Day07Solver : IPuzzleSolver
 {
 	public string Title => "The Treachery of Whales";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var input = rawInput
-			.Single(entry => !string.IsNullOrWhiteSpace(entry))
-			.Split(',')
-			.Select(int.Parse)
-			.ToArray();
-
-		Part1Solution = SolvePart1(input).ToString();
-		Part2Solution = SolvePart2(input).ToString(CultureInfo.InvariantCulture);
-	}
-
-	private static int SolvePart1(IReadOnlyCollection<int> crabPositions)
-	{
+		var crabPositions = GetCrabPositions(input);
+		
 		var minPos = crabPositions.Min();
 		var maxPos = crabPositions.Max();
 
@@ -34,8 +23,10 @@ public class Day07Solver : IPuzzleSolver
 		return cheapestFuel;
 	}
 
-	private static double SolvePart2(int[] crabPositions)
+	public object GetPart2Solution(string[] input)
 	{
+		var crabPositions = GetCrabPositions(input);
+		
 		List<(int Position, int Count)> positionAndCrabCount = crabPositions
 			.GroupBy(pos => pos)
 			.Select(gr => (gr.Key, gr.Count()))
@@ -67,6 +58,15 @@ public class Day07Solver : IPuzzleSolver
 		}
 
 		return cheapestFuel;
+	}
+
+	private static IReadOnlyCollection<int> GetCrabPositions(string[] input)
+	{
+		return input
+			.Single(entry => !string.IsNullOrWhiteSpace(entry))
+			.Split(',')
+			.Select(int.Parse)
+			.ToArray();
 	}
 }
 

--- a/Source/Year2021/Day08/Solver.cs
+++ b/Source/Year2021/Day08/Solver.cs
@@ -5,46 +5,8 @@ namespace Year2021;
 public class Day08Solver : IPuzzleSolver
 {
 	public string Title => "Seven Segment Search";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
-
-	public void SolvePuzzle(string[] rawInput)
-	{
-		List<(string[] InputValues, string[] OutputValues)> input;
-
-		if (rawInput.Any(entry => !entry.Contains(Separator)))
-		{
-			//We have example input
-			var outputValues = rawInput
-				.Where(entry => !entry.Contains(Separator))
-				.ToList();
-
-			var inputValues = rawInput
-				.Except(outputValues)
-				.Select(inputValue => inputValue.Remove(inputValue.IndexOf(Separator)).Trim()) //Remove separator and preceding space
-				.ToList();
-
-			input = Enumerable.Range(0, inputValues.Count)
-				.Select(i => 
-					(inputValues[i].Split(' '),
-					outputValues[i].Split(' ')))
-				.ToList();
-		}
-		else
-		{
-			//We have real input
-			input = rawInput
-				.Where(entry => !string.IsNullOrWhiteSpace(entry))
-				.Select(entry => entry.Split(Separator))
-				.Select(entry =>
-					(entry[0].Trim().Split(' ').ToArray(),
-					entry[1].Trim().Split(' ').ToArray()))
-				.ToList();
-		}
-
-		Part1Solution = SolvePart1(input).ToString();
-		Part2Solution = SolvePart2(input).ToString();
-	}
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
 	private const char Separator = '|';
 
@@ -83,22 +45,26 @@ public class Day08Solver : IPuzzleSolver
 	private static readonly int SignalLinesSharingE = CharsMakingDigit.Values.Count(value => value.Contains(E));
 	private static readonly int SignalLinesSharingF = CharsMakingDigit.Values.Count(value => value.Contains(F));
 
-	private static int SolvePart1(List<(string[] InputValues, string[] OutputValues)> input)
+	public object GetPart1Solution(string[] input)
 	{
-		var simpleDigitCount = input
+		var values = GetValues(input);
+		
+		var simpleDigitCount = values
 			.SelectMany(entry => entry.OutputValues)
 			.Count(outputValue => SimpleDigits.Contains(outputValue.Length));
 
 		return simpleDigitCount;
 	}
 
-	private static int SolvePart2(List<(string[] InputValues, string[] OutputValues)> input)
+	public object GetPart2Solution(string[] input)
 	{
+		var values = GetValues(input);
+		
 		var inputCharFromGoalChar = new Dictionary<char, char>();
 
 		var total = 0;
 
-		foreach (var line in input)
+		foreach (var line in values)
 		{
 			inputCharFromGoalChar.Clear();
 
@@ -153,5 +119,47 @@ public class Day08Solver : IPuzzleSolver
 		}
 
 		return total;
+	}
+
+	private static IReadOnlyCollection<(string[] InputValues, string[] OutputValues)> GetValues(string[] input)
+	{
+		if (input.All(entry => entry.Contains(Separator)))
+		{
+			return GetRealValues(input);
+		}
+
+		return GetExampleValues(input);
+	}
+
+	private static IReadOnlyCollection<(string[] InputValues, string[] OutputValues)> GetExampleValues(string[] input)
+	{
+		var outputValues = input
+			.Where(entry => !entry.Contains(Separator))
+			.ToList();
+
+		var inputValues = input
+			.Except(outputValues)
+			//Remove separator and preceding space
+			.Select(inputValue => inputValue.Remove(inputValue.IndexOf(Separator)).Trim())
+			.ToList();
+
+		var values = Enumerable.Range(0, inputValues.Count)
+			.Select(i => 
+				(inputValues[i].Split(' '),
+					outputValues[i].Split(' ')))
+			.ToList();
+
+		return values;
+	}
+
+	private static IReadOnlyCollection<(string[] InputValues, string[] OutputValues)> GetRealValues(string[] input)
+	{
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.Select(entry => entry.Split(Separator))
+			.Select(entry =>
+				(entry[0].Trim().Split(' ').ToArray(),
+					entry[1].Trim().Split(' ').ToArray()))
+			.ToList();
 	}
 }

--- a/Source/Year2021/Day09/Solver.cs
+++ b/Source/Year2021/Day09/Solver.cs
@@ -6,21 +6,13 @@ namespace Year2021;
 public class Day09Solver : IPuzzleSolver
 {
 	public string Title => "Smoke Basin";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var input = rawInput
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.ToArray();
-
-		Part1Solution = SolvePart1(input).ToString();
-		Part2Solution = SolvePart2(input).ToString();
-	}
-
-	private static int SolvePart1(string[] heightMap)
-	{
+		var heightMap = GetHeightMap(input);
+		
 		var lowPoints = heightMap.GetLowPointCoordinates()
 			.Select(coordinate => int.Parse((heightMap[coordinate.Y])[coordinate.X].ToString()))
 			.ToList();
@@ -30,8 +22,10 @@ public class Day09Solver : IPuzzleSolver
 		return riskLevelSum;
 	}
 
-	private static int SolvePart2(string[] heightMap)
+	public object GetPart2Solution(string[] input)
 	{
+		var heightMap = GetHeightMap(input);
+		
 		var basinMap = heightMap.GenerateFramedBoolMap();
 
 		var basinOriginCoordinates = heightMap.GetLowPointCoordinates()
@@ -40,6 +34,13 @@ public class Day09Solver : IPuzzleSolver
 		var largestBasins = basinMap.GetLargestBasins(3, basinOriginCoordinates);
 
 		return largestBasins.Aggregate((x, y) => x * y);
+	}
+
+	private string[] GetHeightMap(string[] input)
+	{
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.ToArray();
 	}
 }
 

--- a/Source/Year2021/Day10/Solver.cs
+++ b/Source/Year2021/Day10/Solver.cs
@@ -1,26 +1,17 @@
-﻿using System.Globalization;
-using Common.Interfaces;
+﻿using Common.Interfaces;
 
 namespace Year2021;
 
 public class Day10Solver : IPuzzleSolver
 {
 	public string Title => "Syntax Scoring";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var input = rawInput
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.ToArray();
-
-		Part1Solution = SolvePart1(input).ToString();
-		Part2Solution = SolvePart2(input).ToString(CultureInfo.InvariantCulture);
-	}
-
-	private static int SolvePart1(IEnumerable<string> navigationSystem)
-	{
+		var navigationSystem = GetNavigationSystem(input);
+		
 		var totalSyntaxErrorScore = navigationSystem
 			.Select(line => line.GetSyntaxErrorScore())
 			.Sum();
@@ -28,17 +19,26 @@ public class Day10Solver : IPuzzleSolver
 		return totalSyntaxErrorScore;
 	}
 
-	private static double SolvePart2(IEnumerable<string> navigationSystem)
+	public object GetPart2Solution(string[] input)
 	{
+		var navigationSystem = GetNavigationSystem(input);
+		
 		var completionScores = navigationSystem
 			.Where(line => !line.IsCorrupted())
 			.Select(line => line.GetCompletionScore());
 
 		return completionScores.ToList().GetMiddleScore();
 	}
+
+	private IEnumerable<string> GetNavigationSystem(string[] input)
+	{
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.ToArray();
+	}
 }
 
-public static class Day10Helpers
+internal static class Day10Helpers
 {
 	private static readonly IEnumerable<char> OpeningChars = new List<char> { '(', '[', '{', '<' };
 

--- a/Source/Year2021/Day11/Solver.cs
+++ b/Source/Year2021/Day11/Solver.cs
@@ -5,37 +5,38 @@ namespace Year2021;
 public class Day11Solver : IPuzzleSolver
 {
 	public string Title => "Dumbo Octopus";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var input = rawInput
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.ToArray();
-
-		Part1Solution = SolvePart1(input).ToString();
-		Part2Solution = SolvePart2(input).ToString();
-	}
-
-	private static int SolvePart1(string[] octopusEnergyLevels)
-	{
+		var octopusEnergyLevels = GetOctopusEnergyLevels(input);
+		
 		var energyLevelsFlattened = octopusEnergyLevels.ToFlattened();
 		var flashCounts = energyLevelsFlattened.Simulate(100);
 
 		return flashCounts.Sum();
 	}
 
-	private static int SolvePart2(string[] octopusEnergyLevels)
+	public object GetPart2Solution(string[] input)
 	{
+		var octopusEnergyLevels = GetOctopusEnergyLevels(input);
+		
 		var energyLevelsFlattened = octopusEnergyLevels.ToFlattened();
 		var simultaneousStep = energyLevelsFlattened.SimulateUntilSynchronized();
 
 		return simultaneousStep;
 	}
+
+	private static string[] GetOctopusEnergyLevels(string[] input)
+	{
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.ToArray();
+	}
 }
 
-public static class Day11Helpers
+internal static class Day11Helpers
 {
 	private const int EnergyLevelAfterFlash = 0;
 	private const int EnergyLevelFlash = 10;

--- a/Source/Year2021/Day12/Solver.cs
+++ b/Source/Year2021/Day12/Solver.cs
@@ -7,28 +7,28 @@ public class Day12Solver : IPuzzleSolver
 	public string Title => "Passage Pathing";
 	public bool UsePartSpecificExampleInputFiles => true;
 	
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] input)
+	public object GetPart1Solution(string[] input)
 	{
-		SolvePart1(input);
-	}
+		var connectedCavesMap = GetConnectedCavesMap(input);
 
-	public void SolvePart1(string[] input)
-	{
-		var connectedCavesMap = input
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.Select(entry => entry.Split('-'));
-
-		Part1Solution = GetPart1Solution(connectedCavesMap).ToString();
-	}
-
-	private static int GetPart1Solution(IEnumerable<IEnumerable<string>> connectedCavesMap)
-	{
 		var pathCount = connectedCavesMap.GetPathCountVisitingSmallCavesOnceOrLess();
 
 		return pathCount;
+	}
+
+	public object GetPart2Solution(string[] input)
+	{
+		return "Not implemented";
+	}
+
+	private static IEnumerable<IEnumerable<string>> GetConnectedCavesMap(string[] input)
+	{
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.Select(entry => entry.Split('-'));
 	}
 }
 

--- a/Source/Year2021/Day13/Solver.cs
+++ b/Source/Year2021/Day13/Solver.cs
@@ -5,42 +5,25 @@ namespace Year2021;
 public class Day13Solver : IPuzzleSolver
 {
 	public string Title => "Transparent Origami";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		List<(int X, int Y)> markedPoints = rawInput
-			.TakeWhile(entry => !string.IsNullOrWhiteSpace(entry))
-			.Select(entry => entry.Split(','))
-			.Select(coordinate => (int.Parse(coordinate[0]), int.Parse(coordinate[1])))
-			.ToList();
-
-		List<(char AlongPlane, int Coor)> foldingInstructions = rawInput
-			.SkipWhile(entry => !entry.Contains("fold along"))
-			.Select(entry => entry.Split(' '))
-			.Select(instruction => instruction.Last().Split('='))
-			.Select(foldingInstruction => (foldingInstruction[0].Single(), int.Parse(foldingInstruction[1])))
-			.ToList();
-
-		Part1Solution = SolvePart1(markedPoints, foldingInstructions).ToString();
-		Part2Solution = SolvePart2(markedPoints, foldingInstructions);
-	}
-
-	private static int SolvePart1(
-		IReadOnlyCollection<(int X, int Y)> markedPoints,
-		IEnumerable<(char Plane, int Coor)> foldingInstructions)
-	{
+		var markedPoints = GetMarkedPoints(input);
+		var foldingInstructions = GetFoldingInstructions(input);
+		
 		var markedPaper = markedPoints.CreateAndMarkPaper();
 		markedPaper.Fold(foldingInstructions.First());
 
 		return markedPaper.CountMarks();
 	}
 
-	private static string SolvePart2(
-		IReadOnlyCollection<(int X, int Y)> markedPoints,
-		List<(char Plane, int Coor)> foldingInstructions)
+	public object GetPart2Solution(string[] input)
 	{
+		var markedPoints = GetMarkedPoints(input);
+		var foldingInstructions = GetFoldingInstructions(input);
+		
 		var markedPaper = markedPoints.CreateAndMarkPaper();
 		
 		foreach (var instruction in foldingInstructions)
@@ -49,12 +32,12 @@ public class Day13Solver : IPuzzleSolver
 		}
 
 		var maxX = foldingInstructions
-			.Where(instruction => instruction.Plane == 'x')
+			.Where(instruction => instruction.AlongPlane == 'x')
 			.Select(instruction => instruction.Coor)
 			.Min();
 
 		var maxY = foldingInstructions
-			.Where(instruction => instruction.Plane == 'y')
+			.Where(instruction => instruction.AlongPlane == 'y')
 			.Select(instruction => instruction.Coor)
 			.Min();
 
@@ -70,9 +53,28 @@ public class Day13Solver : IPuzzleSolver
 
 		return "Read the note yourself --^";
 	}
+
+	private List<(int X, int Y)> GetMarkedPoints(string[] input)
+	{
+		return input
+			.TakeWhile(entry => !string.IsNullOrWhiteSpace(entry))
+			.Select(entry => entry.Split(','))
+			.Select(coordinate => (int.Parse(coordinate[0]), int.Parse(coordinate[1])))
+			.ToList();
+	}
+
+	private List<(char AlongPlane, int Coor)> GetFoldingInstructions(string[] input)
+	{
+		return input
+			.SkipWhile(entry => !entry.Contains("fold along"))
+			.Select(entry => entry.Split(' '))
+			.Select(instruction => instruction.Last().Split('='))
+			.Select(foldingInstruction => (foldingInstruction[0].Single(), int.Parse(foldingInstruction[1])))
+			.ToList();
+	}
 }
 
-public static class Day13Helpers
+internal static class Day13Helpers
 {
 	private static int SizeX;
 	private static int SizeY;

--- a/Source/Year2021/Day14/Solver.cs
+++ b/Source/Year2021/Day14/Solver.cs
@@ -5,27 +5,15 @@ namespace Year2021;
 public class Day14Solver : IPuzzleSolver
 {
 	public string Title => "Extended Polymerization";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var polymerTemplate = rawInput.First();
-
-		IDictionary<string, char> charToAddForPair = rawInput
-			.Skip(2)
-			.Select(entry => entry.Split(' '))
-			.ToDictionary(
-				rule => rule.First(), 
-				rule => rule.Last().Single());
-
-		Part1Solution = SolvePart1(polymerTemplate, charToAddForPair).ToString();
-		Part2Solution = SolvePart2(polymerTemplate, charToAddForPair).ToString();
-	}
-
-	private static int SolvePart1(string polymerTemplate, IDictionary<string, char> charToAddForPair)
-	{
-		var resultForPair = charToAddForPair.GetResultForPairDict();
+		var polymerTemplate = GetPolymerTemplate(input);
+		var charByAddForPair = GetCharByAddForPairDictionary(input);
+		
+		var resultForPair = charByAddForPair.GetResultForPairDict();
 
 		foreach (var _ in Enumerable.Range(0, 10))
 		{
@@ -34,14 +22,18 @@ public class Day14Solver : IPuzzleSolver
 
 		var countPerElement = polymerTemplate
 			.GroupBy(ch => ch)
-			.Select(gr => gr.Count());
+			.Select(gr => gr.Count())
+			.ToList();
 
 		return countPerElement.Max() - countPerElement.Min();
 	}
 
-	private static double SolvePart2(string polymerTemplate, IDictionary<string, char> charToAddForPair)
+	public object GetPart2Solution(string[] input)
 	{
-		charToAddForPair.PrepareDictionaries();
+		var polymerTemplate = GetPolymerTemplate(input);
+		var charByAddForPair = GetCharByAddForPairDictionary(input);
+		
+		charByAddForPair.PrepareDictionaries();
 
 		var polymerConfig = polymerTemplate.PreparePolymer();
 
@@ -50,13 +42,25 @@ public class Day14Solver : IPuzzleSolver
 			polymerConfig = polymerConfig.InsertPairs();
 		}
 
-		var elementCount = polymerConfig.GetElementCount();
+		var elementCount = polymerConfig.GetElementCount().ToList();
 
 		return elementCount.Max() - elementCount.Min();
 	}
+
+	private string GetPolymerTemplate(string[] input) => input.First();
+
+	private IDictionary<string, char> GetCharByAddForPairDictionary(string[] input)
+	{
+		return input
+			.Skip(2)
+			.Select(entry => entry.Split(' '))
+			.ToDictionary(
+				rule => rule.First(), 
+				rule => rule.Last().Single());
+	}
 }
 
-public static class Day14Helpers
+internal static class Day14Helpers
 {
 	static IDictionary<string, (string Pair1, string Pair2)> ResultOfPair;
 	static IEnumerable<char> Chars;

--- a/Source/Year2021/Day15/Solver.cs
+++ b/Source/Year2021/Day15/Solver.cs
@@ -5,34 +5,36 @@ namespace Year2021;
 public class Day15Solver : IPuzzleSolver
 {
 	public string Title => "Chiton";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		//Info: The shape of the cavern resembles a square
-		var map = rawInput
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.ToArray();
-
-		Part1Solution = SolvePart1(map).ToString();
-		Part2Solution = SolvePart2(map).ToString(); // Implementation is not finished at all
-	}
-
-	private static double SolvePart1(string[] map)
-	{
+		var map = GetMap(input);
+		
 		var riskLevelMap = map.AsRiskLevelMap();
 		var lowestTotalRisk = riskLevelMap.GetLowestTotalRiskOfSouthEastFacingPath();
 
 		return lowestTotalRisk;
 	}
 
-	private static double SolvePart2(string[] map)
+	// TODO Implementation is not finished at all
+	public object GetPart2Solution(string[] input)
 	{
+		var map = GetMap(input);
+		
 		var riskLevelMap = map.AsRiskLevelMap();
 		var lowestTotalRisk = riskLevelMap.GetLowestTotalRiskOfSouthEastFacingPath(5);
 
 		return lowestTotalRisk;
+	}
+
+	private static string[] GetMap(string[] input)
+	{
+		//Info: The shape of the cavern resembles a square
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.ToArray();
 	}
 }
 

--- a/Source/Year2021/Day17/Solver.cs
+++ b/Source/Year2021/Day17/Solver.cs
@@ -6,26 +6,13 @@ namespace Year2021;
 public class Day17Solver : IPuzzleSolver
 {
 	public string Title => "Trick Shot";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var input = rawInput
-			.Single(entry => !string.IsNullOrWhiteSpace(entry))
-			.Substring("target area: ".Length)
-			.Split(',')
-			.Select(entry => entry.Trim())
-			.ToList();
-
-		var targetArea = input.GetTargetArea();
-
-		Part1Solution = SolvePart1(targetArea).ToString();
-		Part2Solution = SolvePart2(targetArea).ToString();
-	}
-
-	private static int SolvePart1(Area target)
-	{
+		var target = GetTargetArea(input);
+		
 		var yMax = 0;
 
 		var positionsOnPath = new List<Coordinate>();
@@ -64,8 +51,10 @@ public class Day17Solver : IPuzzleSolver
 		return yMax;
 	}
 
-	private static int SolvePart2(Area target)
-    {
+	public object GetPart2Solution(string[] input)
+	{
+		var target = GetTargetArea(input);
+		
 		var possibleInitialVelocities = new List<Velocity>();
 
 		foreach (var velocityX in Enumerable.Range(1, target.Max.X))
@@ -91,6 +80,18 @@ public class Day17Solver : IPuzzleSolver
 		}
 
 		return possibleInitialVelocities.Count;
+	}
+
+	private static Area GetTargetArea(string[] input)
+	{
+		var targetRanges = input
+			.Single(entry => !string.IsNullOrWhiteSpace(entry))
+			.Substring("target area: ".Length)
+			.Split(',')
+			.Select(entry => entry.Trim())
+			.ToList();
+
+		return targetRanges.GetTargetArea();
 	}
 }
 

--- a/Source/Year2021/Day18/Solver.cs
+++ b/Source/Year2021/Day18/Solver.cs
@@ -5,22 +5,13 @@ namespace Year2021;
 public class Day18Solver : IPuzzleSolver
 {
 	public string Title => "Snailfish";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var assignment = rawInput
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.Select(entry => entry.AsSnailFishNumber())
-			.ToList();
-
-		Part1Solution = SolvePart1(assignment).ToString();
-		Part2Solution = SolvePart2(assignment).ToString();
-	}
-
-	private static int SolvePart1(IReadOnlyList<List<object>> numbers)
-	{
+		var numbers = GetAssignment(input);
+		
 		var param = new List<object>(numbers[0]);
 
 		foreach (var i in Enumerable.Range(1, numbers.Count - 1))
@@ -32,17 +23,27 @@ public class Day18Solver : IPuzzleSolver
 		return param.GetMagnitude();
 	}
 
-	private static int SolvePart2(List<List<object>> numbers)
+	public object GetPart2Solution(string[] input)
 	{
+		var numbers = GetAssignment(input);
+		
 		var firstAddends = numbers
 			.Select(number => number.ToFirstAddend())
 			.ToList();
 
 		return Day18Helpers.FindLargestMagnitude(firstAddends, numbers);
 	}
+
+	private static List<List<object>> GetAssignment(string[] input)
+	{
+		return input
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.Select(entry => entry.AsSnailFishNumber())
+			.ToList();
+	}
 }
 
-public static class Day18Helpers
+internal static class Day18Helpers
 {
 	private const int DeepestNestingLevel = 4;
 	private const int ThresholdValue = 9;

--- a/Source/Year2021/Day20/Solver.cs
+++ b/Source/Year2021/Day20/Solver.cs
@@ -5,38 +5,44 @@ namespace Year2021;
 public class Day20Solver : IPuzzleSolver
 {
 	public string Title => "Trench Map";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var enhancementAlgorithm = rawInput.First();
-
-		var basicImage = rawInput
-			.Skip(1)
-			.Where(entry => !string.IsNullOrWhiteSpace(entry))
-			.ToList();
-
-		Part1Solution = SolvePart1(basicImage, enhancementAlgorithm).ToString();
-		Part2Solution = SolvePart2(basicImage, enhancementAlgorithm).ToString();
-	}
-
-	private static int SolvePart1(List<string> imageInput, string algorithm)
-	{
+		var algorithm = GetEnhancementAlgorithm(input);
+		var imageInput = GetBasicImage(input);
+		
 		var lightPixelCount = imageInput.GetFinalLightPixelCount(algorithm, 2);
 
 		return lightPixelCount;
 	}
 
-	private static int SolvePart2(List<string> imageInput, string algorithm)
+	public object GetPart2Solution(string[] input)
 	{
+		var algorithm = GetEnhancementAlgorithm(input);
+		var imageInput = GetBasicImage(input);
+		
 		var lightPixelCount = imageInput.GetFinalLightPixelCount(algorithm, 50);
 
 		return lightPixelCount;
 	}
+
+	private static string GetEnhancementAlgorithm(string[] input)
+	{
+		return input.First();
+	}
+
+	private static List<string> GetBasicImage(string[] input)
+	{
+		return input
+			.Skip(1)
+			.Where(entry => !string.IsNullOrWhiteSpace(entry))
+			.ToList();
+	}
 }
 
-public static class Day20Helpers
+internal static class Day20Helpers
 {
 	private const char DarkPixel = '.';
 	private const char LightPixel = '#';

--- a/Source/Year2021/Day21/Solver.cs
+++ b/Source/Year2021/Day21/Solver.cs
@@ -1,46 +1,53 @@
-﻿using System.Globalization;
-using Common.Interfaces;
+﻿using Common.Interfaces;
 
 namespace Year2021;
 
 public class Day21Solver : IPuzzleSolver
 {
 	public string Title => "Dirac Dice";
-	public string Part1Solution { get; set; } = string.Empty;
-	public string Part2Solution { get; set; } = string.Empty;
+	public object? Part1Solution { get; set; }
+	public object? Part2Solution { get; set; }
 
-	public void SolvePuzzle(string[] rawInput)
+	public object GetPart1Solution(string[] input)
 	{
-		var startingPosition1 = 
-			int.Parse(rawInput
-				.Single(entry => entry.Contains("Player 1"))
-				.Split(' ')
-				.Last());
-
-		var startingPosition2 =
-			int.Parse(rawInput
-				.Single(entry => entry.Contains("Player 2"))
-				.Split(' ')
-				.Last());
-
-		Part1Solution = SolvePart1(startingPosition1, startingPosition2).ToString();
-		Part2Solution = SolvePart2(startingPosition1, startingPosition2).ToString(CultureInfo.InvariantCulture);
-	}
-
-	private static int SolvePart1(int startingPosition1, int startingPosition2)
-	{
+		var startingPosition1 = GetStartingPositionForPlayer1(input);
+		var startingPosition2 = GetStartingPositionForPlayer2(input);
+		
 		var totalDieRolls = Day21Helpers.PlayDeterministicDice(startingPosition1, startingPosition2, out var losingScore);
 
 		return totalDieRolls * losingScore;
 	}
 
-	private static double SolvePart2(int startingPosition1, int startingPosition2)
+	public object GetPart2Solution(string[] input)
 	{
+		var startingPosition1 = GetStartingPositionForPlayer1(input);
+		var startingPosition2 = GetStartingPositionForPlayer2(input);
+		
 		return Day21Helpers.PlayDiracDie(startingPosition1, startingPosition2);
+	}
+
+	private static int GetStartingPositionForPlayer1(string[] input)
+	{
+		return GetStartingPosition(input, "Player 1");
+	}
+
+	private static int GetStartingPositionForPlayer2(string[] input)
+	{
+		return GetStartingPosition(input, "Player 2");
+	}
+
+	private static int GetStartingPosition(string[] input, string playerReference)
+	{
+		var position = input
+			.Single(entry => entry.Contains(playerReference))
+			.Split(' ')
+			.Last();
+		
+		return int.Parse(position);
 	}
 }
 
-public static class Day21Helpers
+internal static class Day21Helpers
 {
 	private const int DeterministicDieGoal = 1000;
 	private const int DeterministicDieMax = 100;

--- a/Source/Year2021Tests/TestsBase.cs
+++ b/Source/Year2021Tests/TestsBase.cs
@@ -108,12 +108,12 @@ public abstract class TestsBase
 
     private void VerifyPart1SolutionAgainstExpectedOutput(string expected)
     {
-        Assert.AreEqual(expected, PuzzleSolver.Part1Solution, "(Part 1)");
+        Assert.AreEqual(expected, PuzzleSolver.Part1Solution?.ToString(), "(Part 1)");
     }
 
     private void VerifyPart2SolutionAgainstExpectedOutput(string expected)
     {
-        Assert.AreEqual(expected, PuzzleSolver.Part2Solution, "(Part 2)");
+        Assert.AreEqual(expected, PuzzleSolver.Part2Solution?.ToString(), "(Part 2)");
     }
 
     private static void InformUserThatVerificationOfPart2WasSkipped()

--- a/Source/Year2022/Day01/Solver.cs
+++ b/Source/Year2022/Day01/Solver.cs
@@ -5,29 +5,30 @@ namespace Year2022;
 public class Day01Solver : IPuzzleSolver
 {
     public string Title => "Calorie Counting";
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
-    public void SolvePuzzle(string[] input)
+    public object GetPart1Solution(string[] input)
     {
-        var puzzleInput = input.GetCaloriesPerElf().ToArray();
-
-        Part1Solution = SolvePart1(puzzleInput).ToString();
-        Part2Solution = SolvePart2(puzzleInput).ToString();
-    }
-
-    private static int SolvePart1(IEnumerable<int> caloriesPerElf)
-    {
+        var caloriesPerElf = GetCaloriesPerElf(input);
+        
         return caloriesPerElf.Max();
     }
 
-    private static int SolvePart2(IEnumerable<int> caloriesPerElf)
+    public object GetPart2Solution(string[] input)
     {
+        var caloriesPerElf = GetCaloriesPerElf(input);
+        
         var topThreeWithMaxCalories = caloriesPerElf
             .OrderByDescending(cal => cal)
             .Take(3);
         
         return topThreeWithMaxCalories.Sum();
+    }
+
+    private static IEnumerable<int> GetCaloriesPerElf(string[] input)
+    {
+        return input.GetCaloriesPerElf().ToArray();
     }
 }
 

--- a/Source/Year2022/Day02/Solver.cs
+++ b/Source/Year2022/Day02/Solver.cs
@@ -6,25 +6,19 @@ public class Day02Solver : IPuzzleSolver
 {
     public string Title => "Rock Paper Scissors";
     
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
-    public void SolvePuzzle(string[] encryptedStrategyGuide)
+    public object GetPart1Solution(string[] input)
     {
-        Part1Solution = SolvePart1(encryptedStrategyGuide).ToString();
-        Part2Solution = SolvePart2(encryptedStrategyGuide).ToString();
-    }
-
-    private static int SolvePart1(IEnumerable<string> encryptedStrategyGuide)
-    {
-        var rounds = encryptedStrategyGuide.GetRoundsForPart1();
+        var rounds = input.GetRoundsForPart1();
         
         return rounds.GetScore();
     }
 
-    private static int SolvePart2(IEnumerable<string> encryptedStrategyGuide)
+    public object GetPart2Solution(string[] input)
     {
-        var rounds = encryptedStrategyGuide.GetRoundsForPart2();
+        var rounds = input.GetRoundsForPart2();
 
         return rounds.GetScore();
     }

--- a/Source/Year2022/Day03/Solver.cs
+++ b/Source/Year2022/Day03/Solver.cs
@@ -6,18 +6,12 @@ public class Day03Solver : IPuzzleSolver
 {
     public string Title => "Rucksack Reorganization";
 
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
-    public void SolvePuzzle(string[] input)
+    public object GetPart1Solution(string[] input)
     {
-        Part1Solution = SolvePart1(input).ToString();
-        Part2Solution = SolvePart2(input).ToString();
-    }
-
-    private static int SolvePart1(IEnumerable<string> rucksackContents)
-    {
-        var contentByCompartments = rucksackContents
+        var contentByCompartments = input
             .Select(content =>
                 new[]
                 {
@@ -31,9 +25,9 @@ public class Day03Solver : IPuzzleSolver
         return misplacedItemTypePerRucksack.Sum(GetPriority);
     }
 
-    private static int SolvePart2(IEnumerable<string> rucksackContents)
+    public object GetPart2Solution(string[] input)
     {
-        var elfGroups = rucksackContents.Chunk(3).ToList();
+        var elfGroups = input.Chunk(3).ToList();
 
         var badgePerElfGroup = elfGroups.Select(GetCommonItem);
         

--- a/Source/Year2022/Day04/Solver.cs
+++ b/Source/Year2022/Day04/Solver.cs
@@ -6,21 +6,13 @@ public class Day04Solver : IPuzzleSolver
 {
     public string Title => "Camp Cleanup";
 
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
-    public void SolvePuzzle(string[] input)
+    public object GetPart1Solution(string[] input)
     {
-        var pairs = input
-            .Select(GetPair)
-            .ToList();
+        var pairs = GetPairs(input);
         
-        Part1Solution = SolvePart1(pairs).ToString();
-        Part2Solution = SolvePart2(pairs).ToString();
-    }
-
-    private static int SolvePart1(IEnumerable<ElfPair> pairs)
-    {
         var fullyOverlappingPairs = pairs
             .Where(IsFullyOverlappingPair)
             .Count();
@@ -28,13 +20,22 @@ public class Day04Solver : IPuzzleSolver
         return fullyOverlappingPairs;
     }
 
-    private static int SolvePart2(IEnumerable<ElfPair> input)
+    public object GetPart2Solution(string[] input)
     {
-        var overlappingPairs = input
+        var pairs = GetPairs(input);
+        
+        var overlappingPairs = pairs
             .Where(IsOverlappingPair)
             .Count();
         
         return overlappingPairs;
+    }
+
+    private static IEnumerable<ElfPair> GetPairs(string[] input)
+    {
+        return input
+            .Select(GetPair)
+            .ToList();
     }
 
     private static bool IsFullyOverlappingPair(ElfPair pair)

--- a/Source/Year2022/Day06/Solver.cs
+++ b/Source/Year2022/Day06/Solver.cs
@@ -6,26 +6,24 @@ public class Day06Solver : IPuzzleSolver
 {
     public string Title => "Tuning Trouble";
 
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
-    public void SolvePuzzle(string[] input)
+    public object GetPart1Solution(string[] input)
     {
-        var datastreamBuffer = input.Single();
+        var datastreamBuffer = GetDatastreamBuffer(input);
         
-        Part1Solution = SolvePart1(datastreamBuffer).ToString();
-        Part2Solution = SolvePart2(datastreamBuffer).ToString();
-    }
-
-    private static int SolvePart1(string datastreamBuffer)
-    {
         return DetectStartOfPacketMarkerEndIndex(datastreamBuffer);
     }
 
-    private static int SolvePart2(string datastreamBuffer)
+    public object GetPart2Solution(string[] input)
     {
+        var datastreamBuffer = GetDatastreamBuffer(input);
+        
         return DetectStartOfMessageMarkerEndIndex(datastreamBuffer);
     }
+    
+    private static string GetDatastreamBuffer(string[] input) => input.Single();
 
     private static int DetectStartOfPacketMarkerEndIndex(string datastreamBuffer)
     {

--- a/Source/Year2022/Day07/Solver.cs
+++ b/Source/Year2022/Day07/Solver.cs
@@ -6,22 +6,16 @@ public class Day07Solver : IPuzzleSolver
 {
     public string Title => "No Space Left On Device";
 
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
     private const string RootDirSign = "/";
     private const string RootDirName = "root";
 
-    public void SolvePuzzle(string[] input)
+    public object GetPart1Solution(string[] input)
     {
-        var totalFileSizeByDirNameDict = GetTotalFileSizeByDirNameDict(input);
+        var totalFileSizeByDirName = GetTotalFileSizeByDirNameDict(input);
         
-        Part1Solution = SolvePart1(totalFileSizeByDirNameDict).ToString();
-        Part2Solution = SolvePart2(totalFileSizeByDirNameDict).ToString();
-    }
-
-    private static double SolvePart1(Dictionary<string, double> totalFileSizeByDirName)
-    {
         const double maxSizeOfRelevantDirectories = 100000;
         
         var totalFileSizesOfRelevantDirectories = totalFileSizeByDirName
@@ -31,8 +25,10 @@ public class Day07Solver : IPuzzleSolver
         return totalFileSizesOfRelevantDirectories.Sum();
     }
 
-    private static double SolvePart2(Dictionary<string, double> totalFileSizeByDirName)
+    public object GetPart2Solution(string[] input)
     {
+        var totalFileSizeByDirName = GetTotalFileSizeByDirNameDict(input);
+        
         const double totalDiskSpace = 70000000;
         const double neededUnusedDiskSpace = 30000000;
 

--- a/Source/Year2022/Day08/Solver.cs
+++ b/Source/Year2022/Day08/Solver.cs
@@ -6,24 +6,13 @@ public class Day08Solver : IPuzzleSolver
 {
     public string Title => "Treetop Tree House";
 
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
-    public void SolvePuzzle(string[] input)
+    public object GetPart1Solution(string[] input)
     {
-        var trees = input
-            .Select(row => row
-                .AsEnumerable()
-                .Select(item => int.Parse(item.ToString()))
-                .ToArray())
-            .ToArray();
+        var trees = GetTrees(input);
         
-        Part1Solution = SolvePart1(trees).ToString();
-        Part2Solution = SolvePart2(trees).ToString();
-    }
-
-    private static int SolvePart1(int[][] trees)
-    {
         var rows = trees[0].Length;
         var cols = trees.Length;
 
@@ -81,8 +70,10 @@ public class Day08Solver : IPuzzleSolver
         return visibleTrees;
     }
 
-    private static int SolvePart2(int[][] trees)
+    public object GetPart2Solution(string[] input)
     {
+        var trees = GetTrees(input);
+        
         var rows = trees[0].Length;
         var cols = trees.Length;
         
@@ -134,5 +125,15 @@ public class Day08Solver : IPuzzleSolver
         }
 
         return highestScenicScore;
+    }
+
+    private int[][] GetTrees(string[] input)
+    {
+        return input
+            .Select(row => row
+                .AsEnumerable()
+                .Select(item => int.Parse(item.ToString()))
+                .ToArray())
+            .ToArray();
     }
 }

--- a/Source/Year2022/Template/Solver.cs
+++ b/Source/Year2022/Template/Solver.cs
@@ -6,21 +6,15 @@ public class Day00Solver : IPuzzleSolver
 {
     public string Title => "";
 
-    public string Part1Solution { get; set; } = string.Empty;
-    public string Part2Solution { get; set; } = string.Empty;
+    public object? Part1Solution { get; set; }
+    public object? Part2Solution { get; set; }
 
-    public void SolvePuzzle(string[] input)
-    {
-        Part1Solution = GetPart1Solution(input).ToString();
-        Part2Solution = GetPart2Solution(input).ToString();
-    }
-
-    private static int GetPart1Solution(IEnumerable<string> input)
+    public object GetPart1Solution(string[] input)
     {
         return 0;
     }
 
-    private static int GetPart2Solution(IEnumerable<string> input)
+    public object GetPart2Solution(string[] input)
     {
         return 0;
     }

--- a/Source/Year2022Tests/TestsBase.cs
+++ b/Source/Year2022Tests/TestsBase.cs
@@ -90,12 +90,12 @@ public abstract class TestsBase
 
     private void VerifyPart1SolutionAgainstExpectedOutput(string expected)
     {
-        Assert.AreEqual(expected, PuzzleSolver.Part1Solution, "(Part 1)");
+        Assert.AreEqual(expected, PuzzleSolver.Part1Solution?.ToString(), "(Part 1)");
     }
 
     private void VerifyPart2SolutionAgainstExpectedOutput(string expected)
     {
-        Assert.AreEqual(expected, PuzzleSolver.Part2Solution, "(Part 2)");
+        Assert.AreEqual(expected, PuzzleSolver.Part2Solution?.ToString(), "(Part 2)");
     }
 
     private string[] GetContentOf(string fileName)


### PR DESCRIPTION
- Changing the data type of `Part1Solution` and `Part2Solution` to `object?`
- Implementing `SolvePuzzle()`, `SolvePart1()` and `SolvePart2()`
- Adding `GetPart1Solution()` and `GetPart1Solution()` (return type `object`)
  - These are now the only two methods that need to be implemented in classes inheriting from `IPuzzleSolver`